### PR TITLE
Replace unmaintained encoding dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT"
 telemetry = ["winapi","libc"]
 
 [dependencies]
-serde = {version = "1.0", features = ["derive"] }
 bitflags = "1.2"
-serde_yaml = "0.8"
-encoding = "0.2.33"
-chrono = "0.4.19"
+chrono = "0.4"
+encoding_rs = "0.8"
 libc = { version = "0.2", optional = true }
+serde = {version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
 winapi = {version = "0.3.9", features = ["std","memoryapi","winnt","errhandlingapi","synchapi","handleapi"], optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Replace the `encoding` dependency with `encoding-rs`. `encoding` hasn't been maintained in five years.

This PR also has some minor cleanups.