### PR TITLE
Fix YAML parse error in session_info()

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -161,7 +161,7 @@ pub struct Session {
     pub track_rubber_state: String,
 
     #[serde(rename = "ResultsPositions")]
-    pub results: Vec<SessionResult>,
+    pub results: Option<Vec<SessionResult>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -774,20 +774,22 @@ mod tests {
 
     #[test]
     fn test_session_info() {
-        match Connection::new()
+        let session_info = Connection::new()
             .expect("Unable to open telemetry")
-            .session_info()
-        {
-            Ok(session) => println!("Track: {}", session.weekend.track_name),
-            Err(e) => println!("Error: {:?}", e),
-        };
+            .session_info();
+        assert!(session_info.is_ok());
     }
 
     #[test]
     fn test_latest_telemetry() {
-        Connection::new()
+        let session_tick: u32 = Connection::new()
             .expect("Unable to open telemetry")
             .telemetry()
-            .expect("Couldn't get latest telem");
+            .expect("Couldn't get latest telem")
+            .get("SessionTick")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert!(session_tick > 0);
     }
 }


### PR DESCRIPTION
When telemetry is captured on a test drive prior to completing the first lap, `session_info()` will fail with the following error:

```
Err(
    Message(
        "invalid type: unit value, expected a sequence",
        Some(
            Pos {
                marker: Marker {
                    index: 2151,
                    line: 97,
                    col: 3,
                },
                path: "SessionInfo.Sessions[0].ResultsPositions",
            },
        ),
    ),
)
```

The YAML is:

```yaml
SessionInfo:
 Sessions:
 - SessionNum: 0
   SessionLaps: unlimited
   SessionTime: unlimited
   SessionNumLapsToAvg: 0
   SessionType: Offline Testing
   SessionTrackRubberState: moderately low usage
   SessionName: TESTING
   SessionSubType: 
   SessionSkipped: 0
   SessionRunGroupsUsed: 0
   ResultsPositions:
   ResultsFastestLap:
   - CarIdx: 255
     FastestLap: 0
     FastestTime: -1.0000
   ResultsAverageLapTime: -1.0000
   ResultsNumCautionFlags: 0
   ResultsNumCautionLaps: 0
   ResultsNumLeadChanges: 0
   ResultsLapsComplete: -1
   ResultsOfficial: 0
```

Note how `ResultsPositions` does not have a value. `serde` cannot decode this to an empty `Vec`, even with `#[serde(default)]`.