### PR TITLE
Remove libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,12 @@ edition = "2018"
 license = "MIT"
 
 [features]
-telemetry = ["winapi","libc"]
+telemetry = ["winapi"]
 
 [dependencies]
 bitflags = "1.2"
 chrono = "0.4"
 encoding_rs = "0.8"
-libc = { version = "0.2", optional = true }
 serde = {version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 winapi = {version = "0.3.9", features = ["std","memoryapi","winnt","errhandlingapi","synchapi","handleapi"], optional = true }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,16 +1,15 @@
 use crate::session::*;
 use encoding_rs::mem::decode_latin1;
-use libc::{c_char, c_void};
 use serde::{Deserialize, Serialize};
 use serde_yaml::from_str as yaml_from;
 use std::convert::TryInto;
 use std::default::Default;
 use std::error::Error;
 use std::ffi::CStr;
-use std::fmt;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::io::Result as IOResult;
 use std::mem::transmute;
+use std::os::raw::{c_char, c_void};
 use std::os::windows::raw::HANDLE;
 use std::slice::from_raw_parts;
 use std::time::Duration;


### PR DESCRIPTION
- We can use types provided by the standard library.
- This will probably create merge conflicts with #10 -- please merge that PR first, and I will address the conflicts.