### PR TITLE
Fix a clippy lint

### DIFF
--- a/src/replay.rs
+++ b/src/replay.rs
@@ -96,7 +96,7 @@ impl Header {
         match NaiveDateTime::parse_from_str(timestamp_str.as_str(), "%Y-%m-%d %H:%M:%S") {
             Ok(val) => result.timestamp = val,
             Err(e) => {
-                println!("Error: {:?} / {}", e, e.to_string());
+                println!("Error: {:?} / {}", e, e);
                 return Err(IOError::new(ErrorKind::InvalidInput, e));
             }
         }


### PR DESCRIPTION
- I'm not sure how useful it is to print the Debug and Display formats of this error, but I'll leave that detail alone.
- The clippy error was:

```
error: `to_string` applied to a type that implements `Display` in `println!` args
  --> src\replay.rs:99:50
   |
99 |                 println!("Error: {:?} / {}", e, e.to_string());
   |                                                  ^^^^^^^^^^^^ help: remove this
   |
note: the lint level is defined here
  --> src\lib.rs:1:9
   |
1  | #![deny(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[deny(clippy::to_string_in_format_args)]` implied by `#[deny(clippy::all)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args
```